### PR TITLE
Stop inlining `process.env`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,9 +58,6 @@ module.exports = {
     // Object assign polyfill
     require('babel-plugin-transform-object-assign'),
 
-    // Inline `process.env` references
-    require('babel-plugin-transform-node-env-inline'),
-
     // Transfrom modules to commonjs
     require('babel-plugin-transform-es2015-modules-commonjs'),
   ],

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "babel-plugin-transform-function-bind": "^6.3.13",
     "babel-plugin-transform-jscript": "^6.3.13",
     "babel-plugin-transform-member-expression-literals": "^6.3.13",
-    "babel-plugin-transform-node-env-inline": "^6.3.13",
     "babel-plugin-transform-object-assign": "^6.3.13",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-plugin-transform-react-jsx": "^6.3.13",


### PR DESCRIPTION
The majority of libraries want to check this at runtime, so let them. For those that would like to embed the current `process.env` they can just include the plugin themselves. This has probably been producing some unwanted behavior as it stands.

/cc @nealgranger 