### PR TITLE
Add `babel-plugin-syntax-export-extensions`.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": [
     "metalab/legacy",
-    "metalab/node"
+    "metalab/node",
+    "metalab/react"
   ]
 }

--- a/index.js
+++ b/index.js
@@ -14,9 +14,14 @@ module.exports = {
     [ require('babel-plugin-transform-react-jsx'), {
       pragma: 'createElement',
     } ],
+    require('babel-plugin-syntax-jsx'),
+
+    // Flow
     require('babel-plugin-transform-flow-strip-types'),
     require('babel-plugin-syntax-flow'),
-    require('babel-plugin-syntax-jsx'),
+
+    // Export extensions
+    require('babel-plugin-syntax-export-extensions'),
 
     // Class Properties
     require('babel-plugin-syntax-class-properties'),

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "babel-plugin-syntax-class-properties": "^6.3.13",
+    "babel-plugin-syntax-export-extensions": "^6.5.0",
     "babel-plugin-syntax-flow": "^6.3.13",
     "babel-plugin-syntax-function-bind": "^6.3.13",
     "babel-plugin-syntax-jsx": "^6.3.13",

--- a/test/test.js
+++ b/test/test.js
@@ -4,5 +4,13 @@ const f = (
   b : number
 ) => a + b;
 
+export default from './test.js';
+
+const createElement = () => {};
+const Foo = () => <div/>;
+const jsx = <Foo/>;
+
 /* eslint no-console: 0 */
-console.log(f(1, 2));
+if (jsx) {
+  console.log(f(1, 2));
+}


### PR DESCRIPTION
This basically offers a nicer way of re-exporting modules from other files.

See:
 * https://github.com/leebyron/ecmascript-more-export-from

/cc @nealgranger 